### PR TITLE
feat: disable exercises for non members

### DIFF
--- a/mon_school/templates/livecode/extension_footer.html
+++ b/mon_school/templates/livecode/extension_footer.html
@@ -45,10 +45,13 @@
   </div>
 </template>
 
-
 <script type="text/javascript">
   $(function() {
     var editorLookup = {};
+
+    if ('is_member' in page_context && !page_context.is_member) {
+      $("pre.exercise").replaceWith('<div class="alert alert-warning">Please join the course to submit exercises.</div>')
+    }
 
     $("pre.example, pre.exercise").each((i, e) => {
       var code = $(e).text();


### PR DESCRIPTION
Don't show the livecode editor with submit button for guests and users who
are not part of the course. They'll see an alert message instead.

Closes #10