### PR TITLE
Fix #87: Not Permitted on comments

### DIFF
--- a/mon_school/mon_school/doctype/lms_sketch/lms_sketch.py
+++ b/mon_school/mon_school/doctype/lms_sketch/lms_sketch.py
@@ -67,10 +67,10 @@ class LMSSketch(Document):
             doc = frappe.get_last_doc("Simple Metric", filters)
         except frappe.exceptions.DoesNotExistError:
             doc = frappe.get_doc(dict(filters, doctype="Simple Metric", value=value))
-            doc.insert()
+            doc.insert(ignore_permissions=True)
         else:
             doc.value = value
-            doc.save()
+            doc.save(ignore_permissions=True)
 
     def get_comment_count(self):
         filters = {


### PR DESCRIPTION
Fixes issue which caused `update_metrics` to fail when user was not an admin, not allowing non-admins to comment on sketches.