### PR TITLE
fix: 400 error on saving the subdomain

### DIFF
--- a/mon_school/www/account/subdomain.html
+++ b/mon_school/www/account/subdomain.html
@@ -19,15 +19,39 @@
       <div class="alert alert-{{message_type}}">{{message}}</div>
     {% endif %}
 
-    <form method="POST">
+    <form>
       <div class="form-group">
         <label for="ip">IP Address</label>
         <input class="form-control" type="text" name="ip" id="ip" value="{{frappe.form_dict.get('ip') or subdomain.ip}}">
       </div>
-      <button type="submit" class="btn btn-primary">Save</button>
+      <button type="button" id="save-button" class="btn btn-primary">Save</button>
     </form>
 
   </div>
 </div>
 
 {% endblock %}
+
+{%- block script %}
+{{ super() }}
+
+<script type="text/javascript">
+  $(function() {
+    function save_ip(ip) {
+      frappe.call('mon_school.www.account.subdomain.save_subdomain', {
+        ip: ip,
+      })
+      .then(r => {
+        //console.log(r);
+      });
+    }
+
+    $("#save-button").click(function() {
+      var ip = $("#ip").val();
+      save_ip(ip);
+    })
+  });
+
+</script>
+
+{%- endblock %}

--- a/mon_school/www/account/subdomain.py
+++ b/mon_school/www/account/subdomain.py
@@ -7,16 +7,6 @@ def get_context(context):
         frappe.local.flags.redirect_location = "/login?redirect-to=/account/subdomain"
         raise frappe.Redirect
 
-    if frappe.request.method == "POST":
-        try:
-            save_subdomain(frappe.form_dict.get("ip"))
-        except frappe.exceptions.ValidationError as e:
-            context.message = str(e)
-            context.message_type = "danger"
-        else:
-            context.message = "Successfully updated the IP address of your subdomain."
-            context.message_type = "success"
-
     context.subdomain = get_subdomain()
 
 def get_subdomain():
@@ -33,6 +23,7 @@ def get_subdomain():
             "ip": ""
         })
 
+@frappe.whitelist()
 def save_subdomain(ip):
     doctype = "Mon School User Subdomain"
     name = frappe.db.exists(doctype, {"user": frappe.session.user})
@@ -50,3 +41,5 @@ def save_subdomain(ip):
             "ip": ip
         })
         doc.insert(ignore_permissions=True)
+    frappe.msgprint("Successfully updated the IP address of your subdomain.")
+    return {"ok": True}


### PR DESCRIPTION
On production, saving the subdomain was failing with 400 error, while it
was working fine locally. Fixed it by using AJAX call to save the IP
instead of a POST request to a portal page.