### PR TITLE
fix:refactor `get_lessons` method to use lms.utils

### DIFF
--- a/mon_school/mon_school/student_progress.py
+++ b/mon_school/mon_school/student_progress.py
@@ -1,5 +1,6 @@
 import sys
 import frappe
+from lms.lms.utils import get_lessons
 
 class StudentProgress:
     """Progress of a student.
@@ -12,7 +13,7 @@ class StudentProgress:
         self.course = course
 
     def get_progress(self):
-        lessons = self.course.get_lessons()
+        lessons = get_lessons(self.course)
         lesson_dict = {lesson.name: lesson for lesson in lessons}
 
         exercises = frappe.get_all("LMS Exercise", filters={"course": self.course.name}, fields=["name", "lesson", "index_label"])

--- a/mon_school/www/mon/progress.py
+++ b/mon_school/www/mon/progress.py
@@ -1,5 +1,7 @@
 import frappe
 from collections import defaultdict, Counter
+from lms.lms.utils import get_lessons
+
 
 def get_context(context):
     context.no_cache = 1
@@ -63,7 +65,7 @@ class BatchReport:
         self.students = course.get_students(batch.name)
         self.students_map = {s.email: s for s in self.students}
 
-        self.lessons = self.course.get_lessons()
+        self.lessons = get_lessons(self.course)
 
     def get_exercises(self, course_name):
         return frappe.get_all("LMS Exercise", {"course": course_name, "lesson": ["!=", ""]}, ["name", "title", "lesson", "index_label"], order_by="index_label")

--- a/mon_school/www/mon/student_progress.py
+++ b/mon_school/www/mon/student_progress.py
@@ -2,6 +2,8 @@ from mon_school.mon_school.plugins import LiveCodeExtension
 import frappe
 from collections import defaultdict, Counter
 from mon_school.mon_school.plugins import LiveCodeExtension
+from lms.lms.utils import get_lessons
+
 
 def get_context(context):
     context.no_cache = 1
@@ -55,7 +57,7 @@ class StudentBatchReport:
 
         self.exercises_dict = {e.name: e for e in self.get_exercises(course.name)}
         self.solutions = {s.exercise: s for s in self.submissions}
-        self.lessons = self.course.get_lessons()
+        self.lessons = get_lessons(self.course)
         self.exercises_by_lesson = defaultdict(list)
         for e in self.exercises:
             self.exercises_by_lesson[e.lesson].append(e)


### PR DESCRIPTION
Quick fix for `get_lessons` method. 

Code was accessing `get_lessons` method, which was not available in LMS Course class. It was refactored to use the method with the same name available in `utils.py` of LMS app.